### PR TITLE
Fix response headers and event listener context

### DIFF
--- a/src/xceptor.js
+++ b/src/xceptor.js
@@ -175,9 +175,8 @@ define('XCeptor', function() {
       xhr.onreadystatechange = function() {
         updateKeys(xhr, xceptor);
         updateKeys(xhr, response);
-        if (xhr.readyState === 3) updateResponseHeaders();
+        if (xhr.readyState > 1) updateResponseHeaders();
         if (xhr.readyState === 4) {
-          updateResponseHeaders();
           complete();
           if (request.isAsync) {
             setTimeout(function() { trigger('load'); });

--- a/src/xceptor.js
+++ b/src/xceptor.js
@@ -106,17 +106,20 @@ define('XCeptor', function() {
         if (list[i] === handler) list.splice(i, 1), i = 0 / 0;
       }
     };
-    var dispatchEvent = function(event) {
-      var list = heap(this, event.type);
-      for (var i = 0; i < list.length; i++) list[i](event);
-      var key = 'on' + event.type;
-      if (typeof this[key] === 'function') this[key](event);
+    var wrapDispatchEvent = function(context) {
+      var dispatchEvent = function(event) {
+        var list = heap(this, event.type);
+        for (var i = 0; i < list.length; i++) list[i].call(context, event);
+        var key = 'on' + event.type;
+        if (typeof this[key] === 'function') this[key].call(context, event);
+      };
+      return dispatchEvent;
     };
     var SimpleEventModel = function() {
       Constructor.apply(this, arguments);
       this.addEventListener = addEventListener;
       this.removeEventListener = removeEventListener;
-      this.dispatchEvent = dispatchEvent;
+      this.dispatchEvent = wrapDispatchEvent(this);
     };
     SimpleEventModel.prototype = Constructor.prototype;
     return SimpleEventModel;


### PR DESCRIPTION
Two commits in this PR, one for each issue:

1. According to [XMLHttpRequest.readyState](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState) on MDN, headers and status are available when `readyState` is `2` (`HEADERS_RECEIVED`).

2. When users reference `this` in an event listener, currently it points to the list of handlers, on behalf of [src/xceptor.js#L98](https://github.com/YanagiEiichi/xceptor/blob/master/src/xceptor.js#L98). For example:

    ```js
    var xhr = new XMLHttpRequest
    xhr.addEventListener('readystatechange', function () {
      console.log(this) //==> should be `xhr` itself, or a wrapped XHR instance
    })
    ```